### PR TITLE
changed http to https

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,8 +32,8 @@ mkdir -p $CACHE_DIR
 if [ ! -d $CACHE_DIR/lftp_$VERSION ]; then
 	echo "Fetching and installing lftp" | indent
 	cd $LFTP_BUILD
-	curl -O http://lftp.yar.ru/ftp/lftp-"$VERSION".tar.xz
-	curl --silent http://lftp.yar.ru/ftp/lftp-"$VERSION".md5sum | grep lftp-"$VERSION".tar.xz > lftp-"$VERSION".tar.xz.md5sum
+	curl -O https://lftp.yar.ru/ftp/lftp-"$VERSION".tar.xz
+	curl --silent https://lftp.yar.ru/ftp/lftp-"$VERSION".md5sum | grep lftp-"$VERSION".tar.xz > lftp-"$VERSION".tar.xz.md5sum
 	md5sum --check lftp-"$VERSION".tar.xz.md5sum
 	tar xvf lftp-"$VERSION".tar.xz
 	cd lftp-"$VERSION"


### PR DESCRIPTION
Heroku isn't able to access http URLs during build. Using https to download lftp sources fixes this.